### PR TITLE
change configuration in image checking phase

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -197,12 +197,11 @@ module.exports = yeoman.generators.Base.extend({
             this.log('\nChecking Docker images in applications directories...');
 
             for (var i = 0; i < this.appsFolders.length; i++) {
-                var mvnPath = this.destinationPath(this.directoryPath + this.appsFolders[i] + 'mvnw');
-                var isMaven = shelljs.test('-f', mvnPath);
+                var isMaven = this.appConfigs[i].buildTool == "maven";
                 var buildFolder = isMaven ? 'target' : 'build';
                 var runCommand = isMaven ? "mvn package docker:build" : "gradle bootRepackage buildDocker";
 
-                    var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/' + buildFolder + '/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
+                var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/' + buildFolder + '/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
                 if (!shelljs.test('-f', imagePath)) {
                     this.log(chalk.red('\nDocker Image not found at ' + imagePath));
                     this.log(chalk.red('Please run "' + runCommand +'" in ' + this.destinationPath(this.directoryPath + this.appsFolders[i]) + ' to generate Docker image'));

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -197,10 +197,15 @@ module.exports = yeoman.generators.Base.extend({
             this.log('\nChecking Docker images in applications directories...');
 
             for (var i = 0; i < this.appsFolders.length; i++) {
-                var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/target/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
+                var mvnPath = this.destinationPath(this.directoryPath + this.appsFolders[i] + 'mvnw');
+                var isMaven = shelljs.test('-f', mvnPath);
+                var buildFolder = isMaven ? 'target' : 'build';
+                var runCommand = isMaven ? "mvn package docker:build" : "gradle bootRepackage buildDocker";
+
+                    var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/' + buildFolder + '/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
                 if (!shelljs.test('-f', imagePath)) {
                     this.log(chalk.red('\nDocker Image not found at ' + imagePath));
-                    this.log(chalk.red('Please run "mvn package docker:build" in ' + this.destinationPath(this.directoryPath + this.appsFolders[i]) + ' to generate Docker image'));
+                    this.log(chalk.red('Please run "' + runCommand +'" in ' + this.destinationPath(this.directoryPath + this.appsFolders[i]) + ' to generate Docker image'));
                     this.abort = true;
                 }
             }


### PR DESCRIPTION
generator now is able to distinquish between maven and gradle configuration in the microservice applications and provide the proper build command to the user on failure.

Fix #10
